### PR TITLE
Duplicate mvn install in integration

### DIFF
--- a/ozone-build.yaml
+++ b/ozone-build.yaml
@@ -264,7 +264,7 @@ spec:
           - bash
           - "-x"
           - "-c"
-          - mvn install -B -f pom.ozone.xml -DskipTests; hadoop-ozone/dev-support/checks/integration.sh; RET=$?; /tools/scripts/collect-junit-failed.sh /workdir $OUTPUT_DIR; exit $RET
+          - hadoop-ozone/dev-support/checks/integration.sh; RET=$?; /tools/scripts/collect-junit-failed.sh /workdir $OUTPUT_DIR; exit $RET
         env:
           - name: TEST_TYPE
             value: integration


### PR DESCRIPTION
`integration.sh` in ozone already runs `mvn install`:
https://github.com/apache/hadoop/blob/8b80ca022df0b2809e3ad84fdf1fa93c6473b520/hadoop-ozone/dev-support/checks/integration.sh#L20

So the workflow executes it twice:
https://github.com/elek/ozone-ci/blob/3f553ed6ad358ba61a302967617de737d7fea01a/byscane/byscane-nightly-wggqd/integration/output.log#L1535
https://github.com/elek/ozone-ci/blob/3f553ed6ad358ba61a302967617de737d7fea01a/byscane/byscane-nightly-wggqd/integration/output.log#L3972

Removing it from the workflow would save ~5 minutes:
https://github.com/elek/ozone-ci/blob/3f553ed6ad358ba61a302967617de737d7fea01a/byscane/byscane-nightly-wggqd/integration/output.log#L5053