### PR TITLE
adjust relative links in report

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -35,7 +35,8 @@ show_results() {
       echo ""
 
       if [ -s "$(dirname "$test")/summary.md" ]; then
-         cat "$(dirname "$test")/summary.md"
+         cat "$(dirname "$test")/summary.md" \
+           | perl -wpl -e "s@\]\((?\!\w+://|/)@$&${TEST}/@g" # adjust relative links
       elif [ -s "$(dirname "$test")/summary.txt" ]; then
          cat "$(dirname "$test")/summary.txt"
       fi


### PR DESCRIPTION
Summary of each test is dumped into the overall report (`README.md`).  Since the latter is one level higher in the directory hierarchy, relative links are broken ([example](https://github.com/elek/ozone-ci/tree/master/trunk/trunk-nightly-20190830-rr75b#failing-tests)).

This change adds the test name (eg. `integration`) to the links.  Absolute (`/...`) links and ones with protocol are not touched.

Sample output:

```
# Failing tests:

 * [org.apache.hadoop.ozone.client.rpc.TestDeleteWithSlowFollower](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestDeleteWithSlowFollower.txt) ([output](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestDeleteWithSlowFollower-output.txt/))
 * [org.apache.hadoop.ozone.TestOzoneConfigurationFields](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.TestOzoneConfigurationFields.txt) ([output](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.TestOzoneConfigurationFields-output.txt/))
 * [some link](http://github.com)
 * [absolute link](/trunk)
 * [org.apache.hadoop.ozone.scm.node.TestQueryNode](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.scm.node.TestQueryNode.txt) ([output](integration/hadoop-ozone/integration-test/org.apache.hadoop.ozone.scm.node.TestQueryNode-output.txt/))
```