### PR TITLE
Fix reference to result repo

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -2,23 +2,23 @@
 DIR=${1:-$PWD}
 INSTANCE=$(basename "$DIR")
 JOB=$(basename $(dirname "$DIR"))
+USER=elek
+REPO=ozone-ci-q4
 
 cd $DIR
 show_results() {
    echo "# Tests with $1 status"
    echo ""
-   for test in $(grep -l -r --include="result" $1 $DIR); do
+   for test in $(grep -l -r --include="result" $1 $DIR | sort); do
       TEST="$(basename $(dirname "$test"))"
       RELATIVE_PATH="$JOB/$INSTANCE/$TEST"
+      GITHUB_SOURCE_URL="https://github.com/${USER}/${REPO}/tree/master/$RELATIVE_PATH"
+      GITHUB_PAGE_URL="https://${USER}.github.io/${REPO}/$RELATIVE_PATH"
 
       echo "## $TEST check is finished with $1 status"
       echo ""
-      echo "   * [output](https://raw.githubusercontent.com/elek/ozone-ci/master/$RELATIVE_PATH/output.log)"
-
-      echo "   * [all collected results](https://github.com/elek/ozone-ci/tree/master/$RELATIVE_PATH)"
-
-      GITHUB_SOURCE_URL="https://github.com/elek/ozone-ci/tree/master/$RELATIVE_PATH"
-      GITHUB_PAGE_URL="https://elek.github.io/ozone-ci/$RELATIVE_PATH"
+      echo "   * [output](https://raw.githubusercontent.com/${USER}/${REPO}/master/$RELATIVE_PATH/output.log)"
+      echo "   * [all collected results](${GITHUB_SOURCE_URL})"
 
       if [ -s "$(dirname "$test")/summary.html" ]; then
          echo "   * [summary.html]($GITHUB_PAGE_URL/summary.html)"
@@ -54,7 +54,7 @@ cat << EOF
 
 # References
 
- * All the results are saved to [here](https://github.com/elek/ozone-ci/tree/master/$JOB/$INSTANCE/)
+ * All the results are saved to [here](https://github.com/${USER}/${REPO}/tree/master/$JOB/$INSTANCE/)
  * The definition is the build is committed to [here](https://github.com/elek/argo-ozone)
     * The build is defined in [this argo workflow XML](https://github.com/elek/argo-ozone/blob/master/ozone-build.yaml)
     * This report is assembled by the [report script](https://github.com/elek/argo-ozone/blob/master/scripts/report.sh)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Link results to [elek/ozone-ci-q4](https://github.com/elek/ozone-ci-q4/)
2. Sort test types (for consistency)

## How was this patch tested?

Ran `report.sh` locally on [latest nightly results](https://github.com/elek/ozone-ci-q4/tree/master/trunk/trunk-nightly-extra-20190930-74rp4) and verified URLs.